### PR TITLE
CS561ASK-50: Added Swift test cases for secure mock APIs

### DIFF
--- a/MyLibrary/Sources/MyLibrary/AuthnService.swift
+++ b/MyLibrary/Sources/MyLibrary/AuthnService.swift
@@ -1,0 +1,33 @@
+import Alamofire
+
+public protocol AuthnService {
+    func getToken(completion: @escaping (_ response: Result<String /* Temperature */, Error>) -> Void)
+}
+
+class AuthnServiceImpl: AuthnService {
+    let url = "http://localhost:3000/v1/auth"
+    
+    func getToken(completion: @escaping (_ response: Result<String /* Temperature */, Error>) -> Void) {
+        AF.request(url, method: .post, parameters: ["username" : "test-user", "password" : "test-password"]).validate(statusCode: 200..<300).responseDecodable(of: Token.self) { response in
+            switch response.result {
+            case let .success(token):
+                print("Recieved Access Token: ", token.accessToken)
+                completion(.success(token.accessToken))
+            case let .failure(error):
+                print("AuthnService Error: ", error)
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+private struct Token: Decodable {
+    let accessToken: String
+    let expires: String
+    
+    enum CodingKeys : String, CodingKey {
+        case accessToken = "access-token"
+        case expires = "expires"
+    }
+    
+}

--- a/MyLibrary/Sources/MyLibrary/GreetingService.swift
+++ b/MyLibrary/Sources/MyLibrary/GreetingService.swift
@@ -1,0 +1,40 @@
+import Alamofire
+
+public protocol GreetingService {
+    func getGreeting(completion: @escaping (_ response: Result<String /* Greeting String */, Error>) -> Void)
+}
+
+class GreetingServiceImpl: GreetingService {
+    private let authnService: AuthnService = AuthnServiceImpl()
+    let url = "http://localhost:3000/v1/hello"
+    
+    
+    func getGreeting(completion: @escaping (_ response: Result<String /* Greeting */, Error>) -> Void) {
+        authnService.getToken { response in
+            switch response {
+            case let .failure(error):
+                print(error)
+                completion(.failure(error))
+            case let .success(token):
+                let headers: HTTPHeaders = [
+                    "Authorization": "Bearer " + token
+                ]
+                AF.request(self.url, method: .get, headers: headers).validate(statusCode: 200..<300).responseDecodable(of: Greeting.self) { response in
+                    switch response.result {
+                    case let .success(greeting):
+                        let msg = greeting.message
+                        print("Recieved Greetings: ", msg)
+                        completion(.success(msg))
+                    case let .failure(error):
+                        print("GreetingService Error: ", error)
+                        completion(.failure(error))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct Greeting: Decodable {
+    let message: String
+}

--- a/MyLibrary/Sources/MyLibrary/MyLibrary.swift
+++ b/MyLibrary/Sources/MyLibrary/MyLibrary.swift
@@ -1,6 +1,6 @@
 public class MyLibrary {
     private let weatherService: WeatherService
-
+    private let greetingSerive: GreetingService = GreetingServiceImpl()
     /// The class's initializer.
     ///
     /// Whenever we call the `MyLibrary()` constructor to instantiate a `MyLibrary` instance,
@@ -8,14 +8,40 @@ public class MyLibrary {
     public init(weatherService: WeatherService? = nil) {
         self.weatherService = weatherService ?? WeatherServiceImpl()
     }
-
+    
+    public func getTemperature(completion: @escaping (Int?) -> Void){
+        weatherService.getTemperature { response in
+            switch response {
+            case let .failure(error):
+                print(error)
+                completion(nil)
+                
+            case let .success(temperature):
+                completion(temperature)
+            }
+        }
+    }
+    
+    public func getGreeting(completion: @escaping (String?) -> Void){
+        greetingSerive.getGreeting { response in
+            switch response {
+            case let .failure(error):
+                print(error)
+                completion(nil)
+                
+            case let .success(greeting):
+                completion(greeting)
+            }
+        }
+    }
+    
     public func isLucky(_ number: Int, completion: @escaping (Bool?) -> Void) {
         // Check the simple case first: 3, 5 and 8 are automatically lucky.
         if number == 3 || number == 5 || number == 8 {
             completion(true)
             return
         }
-
+        
         // Fetch the current weather from the backend.
         // If the current temperature, in Farenheit, contains an 8, then that's lucky.
         weatherService.getTemperature { response in
@@ -23,7 +49,7 @@ public class MyLibrary {
             case let .failure(error):
                 print(error)
                 completion(nil)
-
+                
             case let .success(temperature):
                 if self.contains(temperature, "8") {
                     completion(true)
@@ -34,7 +60,7 @@ public class MyLibrary {
             }
         }
     }
-
+    
     /// Sample usage:
     ///   `contains(558, "8")` would return `true` because 588 contains 8.
     ///   `contains(557, "8")` would return `false` because 577 does not contain 8.

--- a/MyLibrary/Sources/MyLibrary/WeatherService.swift
+++ b/MyLibrary/Sources/MyLibrary/WeatherService.swift
@@ -5,18 +5,33 @@ public protocol WeatherService {
 }
 
 class WeatherServiceImpl: WeatherService {
-    let url = "https://api.openweathermap.org/data/2.5/weather?q=corvallis&units=imperial&appid=<INSERT YOUR API KEY HERE>"
-
+    private let authnService: AuthnService = AuthnServiceImpl()
+    
+    let url = "http://localhost:3000/v1/weather"
+    
     func getTemperature(completion: @escaping (_ response: Result<Int /* Temperature */, Error>) -> Void) {
-        AF.request(url, method: .get).validate(statusCode: 200..<300).responseDecodable(of: Weather.self) { response in
-            switch response.result {
-            case let .success(weather):
-                let temperature = weather.main.temp
-                let temperatureAsInteger = Int(temperature)
-                completion(.success(temperatureAsInteger))
-
+        
+        authnService.getToken { response in
+            switch response {
             case let .failure(error):
+                print(error)
                 completion(.failure(error))
+            case let .success(token):
+                let headers: HTTPHeaders = [
+                    "Authorization": "Bearer " + token
+                ]
+                AF.request(self.url, method: .get, headers: headers).validate(statusCode: 200..<300).responseDecodable(of: Weather.self) { response in
+                    switch response.result {
+                    case let .success(weather):
+                        let temperature = weather.main.temp
+                        let temperatureAsInteger = Int(temperature)
+                        print("Recieved Temperature: ", temperatureAsInteger)
+                        completion(.success(temperatureAsInteger))
+                    case let .failure(error):
+                        print("WeatherService Error: ", error)
+                        completion(.failure(error))
+                    }
+                }
             }
         }
     }
@@ -24,7 +39,7 @@ class WeatherServiceImpl: WeatherService {
 
 private struct Weather: Decodable {
     let main: Main
-
+    
     struct Main: Decodable {
         let temp: Double
     }

--- a/MyLibrary/Tests/MyLibraryTests/MyMockAPITests.swift
+++ b/MyLibrary/Tests/MyLibraryTests/MyMockAPITests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import MyLibrary
+
+final class MyMockAPITests: XCTestCase {
+    
+    func testWeather() throws {
+        let myLibrary = MyLibrary()
+        
+        let expectation = XCTestExpectation(description: "We asked about the temperature and heard back 🎄")
+        var myTemperature : Int? = nil
+        
+        // When
+        myLibrary.getTemperature(completion: { temperature in
+            myTemperature = temperature
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 5)
+
+        // Then
+        XCTAssertNotNil(myTemperature)
+    }
+    
+    func testHello() throws {
+        let myLibrary = MyLibrary()
+        
+        let expectation = XCTestExpectation(description: "We asked about the greeting and heard back 🎄")
+        var myGreeting : String? = nil
+        
+        // When
+        myLibrary.getGreeting(completion: { greeting in
+            myGreeting = greeting
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 5)
+
+        // Then
+        XCTAssertNotNil(myGreeting)
+    }
+
+}
+


### PR DESCRIPTION
Update your Swift client, so that it can access the protected versions of `/v1/hello` and `/v1/weather`.  Your client should be able to authenticate on its own—do not hardcode your JWT inside your client—and then, upon successful completion, access your secure endpoints.  You will want new data models, so that you can deserialize the JSON responses from all three endpoints, as well as tests to run them.  Given your code, we should be able to run swift test and this should run two tests: testHello and testWeather.  Do not worry about unit tests.  Instead, make these integration tests.  The tests should run against your ec2 mock server (which is what makes them integration tests but not E2E tests).